### PR TITLE
CMake: Improve build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,26 @@ jobs:
         cp arm64-osx.cmake universal-osx.cmake
         sed -i '' 's|set(VCPKG_OSX_ARCHITECTURES arm64)|set(VCPKG_OSX_ARCHITECTURES "arm64;x86_64")|' universal-osx.cmake
 
+    - name: Setup NuGet.exe
+      uses: nuget/setup-nuget@v2
+      if: runner.os == 'Linux'
+      with:
+        nuget-version: latest
+
+    - name: Install Mono
+      shell: bash
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt install mono-runtime
+        sudo apt install mono-complete
+
+    - name: Enable vcpkg Github packages registry
+      shell: bash
+      run: |
+        nuget sources add -Name github -Source "https://nuget.pkg.github.com/${GITHUB_REPOSITORY_OWNER}/index.json" -Username ${GITHUB_REPOSITORY_OWNER} -Password ${{secrets.GITHUB_TOKEN}} -StorePasswordInClearText
+        nuget setApiKey ${{secrets.GITHUB_TOKEN}} -Source "https://nuget.pkg.github.com/${GITHUB_REPOSITORY_OWNER}/index.json"
+        nuget sources list
+
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
@@ -115,7 +135,7 @@ jobs:
     - name: Build Deling
       id: main_build
       run: |
-        cmake -B ${{ env.deling_build_path }} --preset=vcpkg -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_INSTALL_PREFIX=${{ env.deling_installation_path }} -DCLI:BOOL=${{ matrix.cmake_cli_arg }} -DGUI:BOOL=${{ matrix.cmake_gui_arg }} -DPRERELEASE_STRING="$PRERELEASE_STRING" ${{ matrix.cmake_extra_args }}
+        cmake -B ${{ env.deling_build_path }} --preset ${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_INSTALL_PREFIX=${{ env.deling_installation_path }} -DCLI:BOOL=${{ matrix.cmake_cli_arg }} -DGUI:BOOL=${{ matrix.cmake_gui_arg }} -DPRERELEASE_STRING="$PRERELEASE_STRING" ${{ matrix.cmake_extra_args }}
         cmake --build ${{ env.deling_build_path }} --target package -j3
 
     - name: Build AppImage (Linux)

--- a/.gitignore
+++ b/.gitignore
@@ -449,7 +449,5 @@ compile_commands.json
 *_qmlcache.qrc
 
 # Custom
-.dist
-
-#msvc builds cmake in out/build
-out/*
+.build
+.install

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-  "cmake.buildDirectory": "${workspaceFolder}/.dist/build",
-  "cmake.configureSettings": {
-    "CMAKE_BUILD_TYPE": "${buildType}",
-    "CMAKE_TOOLCHAIN_FILE": "${workspaceFolder}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-  },
-  "cmake.installPrefix": "${workspaceFolder}/.dist/install"
-}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.25)
 cmake_policy(SET CMP0010 NEW)
 cmake_policy(SET CMP0042 NEW)
 cmake_policy(SET CMP0074 NEW)
@@ -24,6 +24,7 @@ cmake_policy(SET CMP0091 NEW)
 
 set(VCPKG_DISABLE_COMPILER_TRACKING 1)
 set(VCPKG_INSTALL_OPTIONS "--clean-after-build" "--x-use-aria2")
+set(X_VCPKG_APPLOCAL_DEPS_INSTALL ON)
 
 set(RELEASE_NAME "Deling")
 set(GUI_TARGET "${RELEASE_NAME}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,11 +1,82 @@
 {
-  "version": 3,
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 25,
+    "patch": 0
+  },
   "configurePresets": [
     {
-      "name": "vcpkg",
+      "name": "base",
+      "hidden": true,
+      "environment": {
+        "NUGET_CLI_LANGUAGE": "en-us",
+        "VCPKG_ROOT": "${sourceDir}/vcpkg",
+        "VCPKG_BINARY_SOURCES": "clear;nuget,github,readwrite;default,readwrite"
+      },
+      "binaryDir": "${sourceDir}/.build",
+      "installDir": "${sourceDir}/.install",
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    },
+    {
+      "name": "Release",
+      "inherits": "base",
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "RelWithDebInfo",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "Debug",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "MinSizeRel",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MinSizeRel"
       }
     }
-  ]
+  ],
+  "buildPresets": [
+    {
+      "name": "Release",
+      "displayName": "Default",
+      "configurePreset": "Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "RelWithDebInfo",
+      "displayName": "Default",
+      "configurePreset": "RelWithDebInfo",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "Debug",
+      "displayName": "Default",
+      "configurePreset": "Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "MinSizeRel",
+      "displayName": "Default",
+      "configurePreset": "MinSizeRel",
+      "configuration": "MinSizeRel"
+    }
+  ],
+  "vendor": {
+    "microsoft.com/VisualStudioSettings/CMake/1.0": {
+      "hostOS": "Windows",
+      "intelliSenseMode": "windows-msvc-x64"
+    }
+  }
 }


### PR DESCRIPTION
- .github/workflows/build.yml:
  - Skip preset flag as it will be inherited automatically by the chosen build type
  - Add vcpkg Gitub packages registry support ( caching built packages )
  - Install Mono+Nuget separately for Linux runners as it's missing by default ( can't migrate to dotnet nuget because of https://github.com/NuGet/Home/issues/6437 )
- .gitignore: Remove old paths and add .build and .install
- .vscode/settings.json: This file is no more needed since CMakePresets.json is now present
- CMakeLists.txt:
  - Bump to CMake 3.25 as minimum requirement
  - Install vcpkg dependencies on CMake install()
- CMakePresets.json:
  - Bump to version 6 ( available since CMake 3.25 )
  - Introduce build profiles, before the only one available was vcpkg. This allows you to build different build types
  - Introduce vcpkg environments to allow caching built packages
  - Add support for Intellisense on various IDEs on Windows machines

---

This fixes the missing DLLs detected for Windows builds, as well as it enable vcpkg package caching using your personal Github package registry ( which will allow faster builds when the toolchain is always the same ).

Nuget is installed saparely for Linux as the correspective dotnet nuget command, despite running fine on all OSes it misses the setApiKey command, see https://github.com/NuGet/Home/issues/6437

Finally, for anyone willing to contribute to Deling, once they'll open it in their favourite IDE, it will bring some default behaviors:
- Build artifacts will be now stored in `.build` ( unless configured it differently using CMake flags )
- Cmake installs will now be stored in `.install` ( unless configured it differently using CMake flags )
- Intellisense will work out of the box on Windows ( will pick up main app + dependencies code )

In order to enable all of this, the only requirement is to bump the minimum CMake version to 3.25 ( as it is required by `CMakePresets.json` version 6 ).