### PR TITLE
CI: Bring back some best practices from Makou

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
       deling_appbundle_path: ${{ github.workspace }}/../appbundle-deling
       CMAKE_GENERATOR: Ninja
       CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
+      VCPKG_KEEP_ENV_VARS: PATH
 
 
     steps:
@@ -137,6 +138,13 @@ jobs:
       run: |
         cmake -B ${{ env.deling_build_path }} --preset ${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_INSTALL_PREFIX=${{ env.deling_installation_path }} -DCLI:BOOL=${{ matrix.cmake_cli_arg }} -DGUI:BOOL=${{ matrix.cmake_gui_arg }} -DPRERELEASE_STRING="$PRERELEASE_STRING" ${{ matrix.cmake_extra_args }}
         cmake --build ${{ env.deling_build_path }} --target package -j3
+
+    - name: Upload vcpkg build logs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: vcpkg-logs-${{ matrix.package_suffix }}-${{ matrix.interface }}-${{ matrix.build_type }}
+        path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
 
     - name: Build AppImage (Linux)
       if: runner.os == 'Linux' && matrix.interface == 'gui'


### PR DESCRIPTION
- .github/workflows/build.yml
  - Add an env var that preserves the PATH env var in case vcpkg dependencies needs to inherit it ( for eg. the custom installed Qt version via Actions )
  - Add a job that uploads vcpkg build logs for dependencies if they fail to build; this should allow easier troubleshooting if needed

---

This PR brings two best practices learnt while working on this Makou PR: https://github.com/myst6re/makoureactor/pull/209