### PR TITLE
misc: Various minor enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ cmake_policy(SET CMP0074 NEW)
 cmake_policy(SET CMP0091 NEW)
 
 set(VCPKG_DISABLE_COMPILER_TRACKING 1)
-set(VCPKG_INSTALL_OPTIONS "--clean-after-build" "--x-use-aria2")
+set(VCPKG_INSTALL_OPTIONS "--clean-after-build")
 set(X_VCPKG_APPLOCAL_DEPS_INSTALL ON)
 
 set(RELEASE_NAME "Deling")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "deling",
   "version": "1.0.1",
-  "builtin-baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
+  "builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",
   "dependencies": [
     "lz4",
     "vulkan-headers",
@@ -15,12 +15,12 @@
     },
     {
       "name": "vulkan-headers",
-      "version": "1.3.296.0",
-      "port-version": 0
+      "version": "1.4.304.1",
+      "port-version": 1
     },
     {
       "name": "zlib",
-      "version": "1.3",
+      "version": "1.3.1",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
- vcpkg: Bump to 2025.04.09
- vcpkg.json: Bump baseline, bump ports version to latest
- CMakeLists.txt: remove aria flag for vcpkg as is no more supported

---

Main goal is to bump vcpkg to the latest stable available, and bump dependencies to the latest version available