### PR TITLE
Implement TDW Mass Export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,8 @@ set(PROJECT_SOURCES
     "src/SpecialCharactersDialog.h"
     "src/TdwManagerDialog.cpp"
     "src/TdwManagerDialog.h"
+    "src/TdwExporter.cpp"
+    "src/TdwExporter.h"
     "src/TextExporter.cpp"
     "src/TextExporter.h"
     "src/TextExporterWidget.cpp"

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -24,6 +24,7 @@
 #include "ScriptExporter.h"
 #include "EncounterExporter.h"
 #include "BackgroundExporter.h"
+#include "TdwExporter.h"
 #include "widgets/PageWidget.h"
 #include "widgets/MsdWidget.h"
 #include "widgets/JsmWidget.h"
@@ -84,6 +85,7 @@ MainWindow::MainWindow()
 	menuExportAll->addAction(tr("Scripts..."), this, SLOT(exportAllScripts()));
 	menuExportAll->addAction(tr("Random Encounters..."), this, SLOT(exportAllEncounters()));
 	menuExportAll->addAction(tr("Backgrounds..."), this, SLOT(exportAllBackground()));
+	menuExportAll->addAction(tr("Additional Characters..."), this, SLOT(exportAllAdditionalFont()));
 	actionImport = menu->addAction(tr("Import..."), this, SLOT(importCurrent()));
 	menuImportAll = menu->addMenu(tr("Import all"));
 	menuImportAll->addAction(tr("Texts..."), this, SLOT(importAllTexts()));
@@ -1048,6 +1050,31 @@ void MainWindow::exportAllBackground()
 	BackgroundExporter exporter(fieldArchive);
 
 	if (!exporter.toDir(dirPath, &progress) && !progress.observerWasCanceled()) {
+		QMessageBox::warning(this, tr("Error"), exporter.errorString());
+	}
+}
+
+void MainWindow::exportAllAdditionalFont()
+{
+	if (!fieldArchive)
+		return;
+
+	QString oldPath = Config::value("export_path").toString();
+
+	QString dirPath =
+	    QFileDialog::getExistingDirectory(this, tr("Export"), oldPath);
+	if (dirPath.isNull()) {
+		return;
+	}
+
+	Config::setValue("export_path", dirPath);
+
+	ProgressWidget progress(tr("Export..."), ProgressWidget::Cancel, this);
+
+	TdwExporter exporter(fieldArchive);
+
+	if (!exporter.toDir(dirPath, &progress)
+	    && !progress.observerWasCanceled()) {
 		QMessageBox::warning(this, tr("Error"), exporter.errorString());
 	}
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -73,6 +73,7 @@ private slots:
 	void exportAllScripts();
 	void exportAllEncounters();
 	void exportAllBackground();
+	void exportAllAdditionalFont();
 	void importCurrent();
 	void optimizeArchive();
 	void manageArchive();

--- a/src/TdwExporter.cpp
+++ b/src/TdwExporter.cpp
@@ -1,0 +1,75 @@
+/****************************************************************************
+ ** Deling Final Fantasy VIII Field Editor
+ ** Copyright (C) 2009-2024 Arzel Jérôme <myst6re@gmail.com>
+ **
+ ** This program is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ****************************************************************************/
+#include "TdwExporter.h"
+#include "FieldPC.h"
+#include "FieldArchivePC.h"
+#include "ArchiveObserver.h"
+
+TdwExporter::TdwExporter(FieldArchive *archive) : _archive(archive)
+{
+}
+
+bool TdwExporter::toDir(const QDir &dir, ArchiveObserver *observer)
+{
+	if (!_archive) {
+		return false;
+	}
+
+	FieldArchiveIterator it = _archive->iterator();
+
+	if (observer) {
+		observer->setObserverMaximum(quint32(_archive->nbFields()));
+	}
+
+	int i = 0;
+
+	while (it.hasNext()) {
+		Field *f = it.next();
+
+		if (observer) {
+			if (observer->observerWasCanceled()) {
+				return false;
+			}
+			observer->setObserverValue(i++);
+		}
+
+		if (f && f->isOpen() && f->hasTdwFile()) {
+			TdwFile *tdw = f->getTdwFile();
+			char *format = (char *)"PNG";
+			if (tdw->isOpen()) {
+				QString fieldName = f->name();
+
+				if (fieldName.isEmpty()) {
+					fieldName = QObject::tr("Unamed");
+				}
+				QByteArray data;
+				if (tdw) {
+					QString path = dir.filePath(fieldName + ".png");
+					QFile f(path);
+					tdw->image(TdwFile::Color::White).save(path, format);
+				} else {
+					_lastErrorString =
+					    QObject::tr("Unable to export '%1' to image")
+					        .arg(fieldName);
+				}
+			}
+		}
+	}
+
+	return true;
+}

--- a/src/TdwExporter.h
+++ b/src/TdwExporter.h
@@ -1,0 +1,37 @@
+/****************************************************************************
+ ** Deling Final Fantasy VIII Field Editor
+ ** Copyright (C) 2009-2024 Arzel Jérôme <myst6re@gmail.com>
+ **
+ ** This program is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ****************************************************************************/
+#pragma once
+
+#include <QtCore>
+
+#include "FieldArchive.h"
+
+class TdwExporter
+{
+public:
+	explicit TdwExporter(FieldArchive *archive);
+	bool toDir(const QDir &dir, ArchiveObserver *observer = nullptr);
+	inline const QString &errorString() const
+	{
+		return _lastErrorString;
+	}
+
+private:
+	FieldArchive *_archive;
+	QString _lastErrorString;
+};


### PR DESCRIPTION
**Feature**: Adds "Additional Characters..." under File > Export All. Prompts the user to pick a folder and dumps images (in .PNG format, using the White palette) there. 

--

Hello! C++ noob here, but I wanted to mass export the JP font texture files for my own script dumping purposes so I figured I'd code it in. No AI was used, just trying to learn by doing.

Basically reused logic from BackgroundExporter/TdwWidget2 with a few changes. Pointers appreciated if there's any best practices I'm unaware of.