### PR TITLE
Fix import all texts bug

### DIFF
--- a/src/FieldArchive.cpp
+++ b/src/FieldArchive.cpp
@@ -66,7 +66,7 @@ Field *FieldArchive::getField(int id) const
 
 Field *FieldArchive::getFieldFromMapId(int mapId) const
 {
-	int fieldId = fieldsSortByMapId.value(QString("%1").arg(mapId, 3, 10, QChar('0')), -1);
+	int fieldId = fieldsSortByMapId.value(QString("%1").arg(mapId, 4, 10, QChar('0')), -1);
 
 	return getField(fieldId);
 }


### PR DESCRIPTION
When getFieldFromMapId is being called from TextExporter's fromCsv function to grab the field ID, it fails because the key's length isn't correct. This fixes that issue and solves #48.